### PR TITLE
docs: standardize test commands to use poetry run

### DIFF
--- a/collaborators/training/integration-tests.md
+++ b/collaborators/training/integration-tests.md
@@ -692,14 +692,14 @@ class TestAttendanceSystem(unittest.TestCase):
 ## Running Integration Tests
 
 ```bash
-# Run only integration tests (name them test_*_integration.py)
-python -m unittest discover -s tests -p "*_integration.py"
+# Run integration tests using the project's test runner
+poetry run python tests/run_tests.py integration
 
 # Run with verbose output
-python -m unittest discover -s tests -p "*_integration.py" -v
+poetry run python tests/run_tests.py integration -v
 
 # Run specific test class
-python -m unittest test_student_integration.TestStudentRegistrationFlow
+poetry run python -m unittest test_student_integration.TestStudentRegistrationFlow
 ```
 
 ---

--- a/collaborators/training/smoke-tests.md
+++ b/collaborators/training/smoke-tests.md
@@ -581,11 +581,11 @@ class TestCriticalPathStudentRegistration(unittest.TestCase):
 Make smoke tests fast to run:
 
 ```bash
-# Run only smoke tests
-python -m unittest discover -s tests/smoke -v
+# Run smoke tests using the project's test runner
+poetry run python tests/run_tests.py sanity
 
 # Or use a custom marker (if using pytest)
-pytest tests/ -m smoke
+poetry run pytest tests/ -m smoke
 ```
 
 ---
@@ -643,16 +643,16 @@ Use this checklist when creating smoke tests:
 ## Running Smoke Tests
 
 ```bash
-# Run smoke tests only
-python -m unittest discover -s tests/smoke -v
+# Run smoke tests using the project's test runner
+poetry run python tests/run_tests.py sanity
 
 # Run with timeout (fail if tests take too long)
-python -m unittest discover -s tests/smoke -v 2>&1 | timeout 60s
+poetry run python tests/run_tests.py sanity --timeout 60
 
 # In CI/CD pipeline
 # .github/workflows/test.yml
 # - name: Run smoke tests
-#   run: python -m unittest discover -s tests/smoke
+#   run: poetry run python tests/run_tests.py sanity
 ```
 
 ---

--- a/contributors/training/unit-testing.md
+++ b/contributors/training/unit-testing.md
@@ -346,7 +346,7 @@ if __name__ == "__main__":
 
 Run from terminal:
 ```bash
-python test_grade_calculator.py
+poetry run python test_grade_calculator.py
 ```
 
 Output:
@@ -481,7 +481,7 @@ project/
 
 Run all tests at once:
 ```bash
-python -m unittest discover tests
+poetry run python tests/run_tests.py unit
 ```
 
 ---
@@ -880,7 +880,7 @@ if __name__ == "__main__":
 
 Run with verbose output:
 ```bash
-python test_attendance.py
+poetry run python test_attendance.py
 ```
 
 Output:
@@ -933,19 +933,19 @@ OK
 
 ```bash
 # Run a single test file
-python test_attendance.py
+poetry run python test_attendance.py
 
-# Run all tests in a directory
-python -m unittest discover tests
+# Run all unit tests using the project's test runner
+poetry run python tests/run_tests.py unit
 
 # Run with verbose output
-python -m unittest discover -v
+poetry run python tests/run_tests.py unit -v
 
 # Run only specific test class
-python -m unittest test_attendance.TestMarkAttendance
+poetry run python -m unittest test_attendance.TestMarkAttendance
 
 # Run only specific test
-python -m unittest test_attendance.TestMarkAttendance.test_mark_present
+poetry run python -m unittest test_attendance.TestMarkAttendance.test_mark_present
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Update all training documentation to consistently require `poetry run python tests/run_tests.py <flags>` instead of direct python/unittest commands
- Aligns with permission settings that deny direct test execution

## Changes
- `collaborators/training/integration-tests.md`: Use poetry run for integration tests
- `collaborators/training/smoke-tests.md`: Use poetry run for smoke tests  
- `contributors/training/unit-testing.md`: Use poetry run for unit tests

## Test plan
- [x] Documentation review confirms all test commands now use `poetry run`
- [x] Commands align with `.claude/settings.local.json` permission settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)